### PR TITLE
Update settings.py for MEDIA_ROOT

### DIFF
--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -131,7 +131,7 @@ STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 
 # Media Files (uploaded from users)
 MEDIA_URL = "media/"
-MEDIA_ROOT = BASE_DIR / "media"
+MEDIA_ROOT = os.environ["RAILWAY_VOLUME_MOUNT_PATH"]
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.0/ref/settings/#default-auto-field


### PR DESCRIPTION
Railway provides "RAILWAY_VOLUME_MOUNT_PATH" as a environment variable. Instead of using "BASE_DIR" use this variable to save your data to the persistent storage. Make sure that the mount path of your persistent volume is at "/app/media".